### PR TITLE
Change API requset to top level, reduce requests when change routers

### DIFF
--- a/src/components/AppBar.js
+++ b/src/components/AppBar.js
@@ -29,24 +29,22 @@ const useStyles = makeStyles(theme => ({
   link: { color: '#FFF', textDecoration: 'none' }
 }));
 
-function China() {
+function China({overall}) {
   return (
     <div className="bodyContainer">
       <div className="bodyTop">     
-        <OverallData showGlobal={false} overall={{}}/>
+        <OverallData showGlobal={false} overall={overall}/>
       </div>
       <div className="bodyBottom">
         <div className="bodyLeft"> <MapChina/> </div>
         <div className="bodyRight"> <ChinaTrend/> </div>
       </div>
     </div>
-  )
+  );
 }       
 
 // global data is also for homepage
-function Global() {
-
-  const {loaded, overall, mapData, tableData} = useAppData();
+function Global({loaded, overall, globalMap, tableData}) {
 
   return (  
     <div className="bodyContainer">
@@ -55,7 +53,7 @@ function Global() {
       </div>
       <div className="bodyBottom">   
       <div className="bodyGlobalMap">
-        <MapGlobal mapData={mapData} loaded={loaded}/>
+        <MapGlobal mapData={globalMap} loaded={loaded}/>
       </div>    
       <div className="bodyGlobalTable">
         { 
@@ -75,11 +73,11 @@ function Global() {
   )
 }  
 
-function News() {
+function News({overall}) {
   return (
     <div className="bodyContainer">
       <div className="bodyTop">     
-        <OverallData showGlobal={false}/>
+        <OverallData showGlobal={false} overall={overall}/>
       </div>
       <div className="bodyBottom">
         <LatestNews />
@@ -106,7 +104,11 @@ function Navigator() {
 }
 
 export default function TopAppBar() {
+
   const classes = useStyles();
+  const {loaded, globalOverall, chinaOverall, otherOverall, globalMap, tableData} = useAppData();
+  // console.log('appbar', globalOverall);
+
   return (
     <div className={classes.root}>
       <AppBar position="static" >
@@ -123,9 +125,18 @@ export default function TopAppBar() {
       </AppBar>
       {/* Router Configuration */}
       <Switch>
-          <Route exact path="/" component={Global}></Route>
-          <Route path="/china" component={China}></Route>
-          <Route path="/news" component={News}></Route>
+          <Route 
+            exact path="/"
+            component={() => <Global loaded={loaded} globalMap={globalMap} tableData={tableData} overall={globalOverall}/>}
+          />
+          <Route 
+            path="/china" 
+            component={() => <China loaded={loaded} overall={chinaOverall} />}
+          />
+          <Route 
+            path="/news" 
+            component={() => <News loaded={loaded} overall={otherOverall} />}
+          />
       </Switch>
     </div>
   );

--- a/src/components/LineChart.js
+++ b/src/components/LineChart.js
@@ -15,6 +15,7 @@ export default function ChinaTrend() {
     axios.get('http://www.dzyong.top:3005/yiqing/history').then((hisData) => {
         setData(hisData.data.data);
         setReady(true);
+        console.log(hisData.data.data);
     }).catch(e => { console.log('Request history data in China', e) })
   }, []);
 

--- a/src/components/MapChina.js
+++ b/src/components/MapChina.js
@@ -24,6 +24,7 @@ export default function MapChina() {
         { name: p.provinceName, value: p.confirmedNum })
       );    
       setData(tempData);
+      console.log('Province Data', provinces.data.data);
       setReady(true);
     }).catch(e => { console.log('Request province data in China', e) })
   },[]);

--- a/src/components/Overall.js
+++ b/src/components/Overall.js
@@ -1,28 +1,15 @@
 import React, {useState, useEffect} from 'react';
-import axios from 'axios';
 import '../styles/Overall.css';
 
 export default function OverallData ({showGlobal, overall}) {  
-  const [data, setData] = useState(showGlobal ? overall: { });
+  
+  const [data, setData] = useState({time: '', confirmed: '', suspect: '', cured: '', death: '', fatality: '' });
 
   useEffect(() => {
-    if(showGlobal) {setData(overall)}
-    else {
-    axios.get('http://www.dzyong.top:3005/yiqing/total')
-      .then((total) => {
-          const {date, diagnosed, suspect, cured, death} = total.data.data[0];
-          setData({ 
-            time: date,
-            confirmed: diagnosed, 
-            suspect: suspect,
-            cured: cured, 
-            death: death,
-            fatality: (100 * death / (diagnosed + cured)).toFixed(2) + '%'
-          });
-      }).catch(e => { console.log('Request latest overall data in China', e) });
-    }
-  },[overall, showGlobal]);
-
+    if(overall)  setData(overall);
+  }, [overall]);
+  
+  console.log('overdata', overall);
   return (
     <>
       <div>As of <span className="dataTime">{data.time}</span></div>

--- a/src/hooks/reducer.js
+++ b/src/hooks/reducer.js
@@ -1,21 +1,30 @@
-export const SET_OVERALL = "SET_OVERALL";
-export const SET_MAP_DATA = "SET_MAP";
-export const SET_TABLE_DATA = "SET_TABLE";
-export const SET_LOAD_STATUS = "SET_LOAD";
+export const SET_OTHER_OVERALL = "SET_OTHER_OVERALL";
+export const SET_CHINA_OVERALL = "SET_CHINA_OVERALL";
+export const SET_GLOBAL_OVERALL = "SET_GLOBAL_OVERALL";
+export const SET_GLOBAL_MAP = "SET_GLOBAL_MAP";
+export const SET_CHINA_MAP = "SET_CHINA_MAP";
+export const SET_GLOBAL_TABLE = "SET_GLOBAL_TABLE";
+export const SET_LOAD_STATUS = "SET_LOAD_STATUS";
 
 export default function reducer(state, action) {
 
   switch (action.type) {
     case SET_LOAD_STATUS:
       return { ...state, loaded: action.loaded };
-    
-    case SET_OVERALL:
-      return { ...state, overall: action.overall };
 
-    case SET_MAP_DATA:
-      return { ...state, mapData: action.mapData };
+    case SET_OTHER_OVERALL:
+      return { ...state, otherOverall: action.otherToll };
 
-    case SET_TABLE_DATA:
+    case SET_CHINA_OVERALL:
+      return { ...state, chinaOverall: action.chinaToll };
+
+    case SET_GLOBAL_OVERALL:
+      return { ...state, globalOverall: action.globalToll };
+
+    case SET_GLOBAL_MAP:
+      return { ...state, globalMap: action.globalMap };
+
+    case SET_GLOBAL_TABLE:
       return { ...state, tableData: action.tableData }; 
 
     default:


### PR DESCRIPTION
1. Move API request to top level components and this will reduce api call count, as we don't need update in seconds or minuetes; This also make page loading fast;
2. Use another request to patch the suspected cases count as the original api always returns 0;
3. Use a new AIP request to request history data as the one used  is unavailable right now.